### PR TITLE
Fix libm missing link error by adding -lm

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ BIN_DIR = ../bin
 INC_DIR	= ../include
 LIB_DIR	= ../lib
 INCL	= -I$(INC_DIR) `pkg-config --cflags opencv gtk+-2.0`
-LIBS	= -L$(LIB_DIR) -lopensift `pkg-config --libs opencv gtk+-2.0`
+LIBS	= -L$(LIB_DIR) -lopensift -lm `pkg-config --libs opencv gtk+-2.0`
 OBJ	= imgfeatures.o utils.o sift.o kdtree.o minpq.o xform.o
 BIN     = siftfeat match dspfeat
 


### PR DESCRIPTION
Linking in Ubuntu 13.10, gcc version 4.8.1:

gcc -I../include pkg-config --cflags opencv gtk+-2.0 siftfeat.c -o ../bin/siftfeat -L../lib -lopensift pkg-config --libs opencv gtk+-2.0
/usr/bin/ld: ../lib/libopensift.a(imgfeatures.o): undefined reference to symbol 'atan2@@GLIBC_2.0'
/lib/i386-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status

Adding -lm to the Makefile can fix the problem.
